### PR TITLE
upgrade to ruby 2.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.0.0'
+ruby '2.2.3'
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 gem 'rails', '~> 4'
@@ -36,8 +36,12 @@ gem 'pothoven-attachment_fu'
 gem 'nokogiri'
 gem 'email_validator'
 
+# Support for syck. Syck was removed from the ruby stdlib.
+gem 'syck'
+
 # Deploy with Capistrano
 gem 'capistrano'
+gem 'capistrano-passenger'
 
 # Production-specific
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,8 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (~> 1.3)
+    capistrano-passenger (0.1.1)
+      capistrano (~> 3.0)
     capybara (2.4.4)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -267,6 +269,7 @@ GEM
       colorize (>= 0.7.0)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    syck (1.0.5)
     therubyracer (0.12.2)
       libv8 (~> 3.16.14.0)
       ref
@@ -312,6 +315,7 @@ DEPENDENCIES
   bullet
   byebug
   capistrano
+  capistrano-passenger
   capybara
   cucumber-rails (~> 1.4.2)
   database_cleaner
@@ -334,6 +338,7 @@ DEPENDENCIES
   rubycas-client (~> 2.3.9)
   sass-rails (>= 3.2)
   simplecov
+  syck
   therubyracer
   ucb_ldap (= 2.0.0.pre5)
   uglifier
@@ -341,3 +346,6 @@ DEPENDENCIES
   will_paginate (~> 3.0.pre2)
   will_paginate-bootstrap
   yard
+
+BUNDLED WITH
+   1.10.6

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,9 +1,10 @@
-require 'yaml'
-YAML::ENGINE.yamler='syck'
-
 require 'rubygems'
 
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+
+require 'yaml'
+require 'syck'
+#YAML::ENGINE.yamler='syck'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -190,14 +190,6 @@ ActiveRecord::Schema.define(version: 20151026183101) do
     t.datetime "updated_at"
   end
 
-  create_table "reviews", force: :cascade do |t|
-    t.integer  "user_id"
-    t.text     "body"
-    t.integer  "rating"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-  end
-
   create_table "sessions", force: :cascade do |t|
     t.string   "session_id", limit: 255, null: false
     t.text     "data"


### PR DESCRIPTION
Changed Gemfile to use ruby 2.2.3, added ‘syck'

other actions required:
	-change to ruby version 2.2.3 (if using rbevn, set .ruby-version to 2.2.3)
	-bundler install (On mac OSx, may need to sudo xcrun cc to agree to Xcode license)

potential errors:
	-acts-as-taggable-on
	-capistrano
	-capistrano-passenger
	-haml